### PR TITLE
Fix conflict with the private repo Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,4 @@ push-test:
 	git checkout -b car-api && git pull private car-api --rebase && git push origin car-api
 
 delete-test:
-	git reset --hard && git checkout master && git push -d origin car-api && git branch -D car-api
+	git reset --hard && git checkout master && git branch -D car-api && git push -d origin car-api


### PR DESCRIPTION
Make the Makefile match the [private repo](https://github.com/eeveebank/remote-pair-programming-test-private/blob/car-api/Makefile) so it doesn't conflict.  It seems the order of the cleanup changed but the root Makefile in the non private repo wasn't kept inline.